### PR TITLE
adds tomdoc documentation to Search plugin

### DIFF
--- a/scripts/search.js
+++ b/scripts/search.js
@@ -1,3 +1,19 @@
+# Description
+#   Allows Hubot to geocode using Mapzen Search / Pelias
+#
+# Dependencies:
+#   request
+#
+# Configuration:
+#   api_key
+#
+# Commands:
+#   search <parameters> - calls Mapzen/v1/search (e.g. text=Union Square)
+#
+# Authors:
+#   @orangejulius
+#   @dianashk
+
 'use strict';
 
 var request = require('request');


### PR DESCRIPTION
Hubot plugins like Tomdoc documentation. It's what lets `hubot help` [list any commands](https://github.com/github/hubot-scripts#writing) that a plugin may add, in addition to improving readability.